### PR TITLE
add details for all first-season speakers

### DIFF
--- a/prizes.md
+++ b/prizes.md
@@ -15,7 +15,7 @@ Winner: Christiane Spring, University of Bristol - “The Polluted Brain: Logist
 
 [Bio](https://qmrg.github.io/blog/2020/11/10/bio-spring)
 
-Runner up: Philip Cowley, University of York - "Comparing the effects of turbine arrays and climate change on future marine species distributions".
+Runner up: Philip Cowing, University of York - "Comparing the effects of turbine arrays and climate change on future marine species distributions".
 
 **2019**
 

--- a/sad_interviews.md
+++ b/sad_interviews.md
@@ -13,13 +13,42 @@ Join us now for SAD: The Interviews, long-form, informal conversations with infl
 
 ## Spring'21
 
-
 ### April 13th - Michael Batty
 
 For our inaugural SAD Interview, we welcome Professor Michael Batty, internationally esteemed scholar of cities, complexity, and urban systems. Professor Batty is Founder and Past Director of the Centre for Advanced Spatial Analysis at University College London, Editor of Environment and Planning B, and 2015 awardee of the Royal Geographical Society's Founder's Medal.
 
 - [Eventbrite](https://www.eventbrite.co.uk/e/spatial-analytics-data-the-interviews-professor-michael-batty-tickets-148357512313#) (16:00 - 17:30 BST)
+- [YouTube](https://www.youtube.com/watch?v=X0N6zrS85H8) 
+- [Soundcloud (pending)]()
 
 ### May 4th - Luc Anselin
 
-TBC
+Luc Anselin is the Stein-Freiler Distinguished Service Professor of Sociology at the University of Chicago, where he founded and directs the Center for Spatial Data Science. Luc is one of the principal developers of the field of spatial econometrics. His work spans political science, sociology, economics, statistics, and urban studies. He was elected to the US National Academy of Sciences in 2008 and the American Academy of Arts and Sciences in 2011.
+
+- [Eventbrite](https://www.eventbrite.co.uk/e/spatial-analytics-and-data-interview-luc-anselin-tickets-151641085569)
+- [YouTube (after recording)]()
+- [Soundcloud (pending)]()
+
+### May 25th - Helen Couclelis
+
+Helen Couclelis is a Professor Emeritus at the University of California, Santa Barbara. After joining the department at UCSB in 1982, Professor Couclelis has held numerous visiting appointments at the University of Waterloo, University of California Berkeley, and Princeton University. She won the University Consortium for Geographic Information Science Career Research Award in 2018 for fundamental contributions to regional science, urban analytics, and geographic information science, and she continues to publish on urban systems, interaction, and uncertainty today.
+
+- [Eventbrite (TBD)]()
+- [YouTube (after recording)]()
+- [Soundcloud (pending)]()
+
+### July 20th - Alison Heppenstall
+
+Alison Heppenstall is a Professor of Geocomputation at the University of Leeds, as well as an ESRC-Alan Turing Professorial Fellow at the Alan Turing Institute. Professor Heppenstall’s research is centered around developing and applying transdisciplinary methods to solve complex spatial problems in Urban Analytics. She is interested in artificial intelligence, machine learning, data analytics, and visualization. 
+
+- [Eventbrite (TBD)]()
+- [YouTube (after recording)]()
+- [Soundcloud (pending)]()
+
+### September 28th - Danny Dorling
+
+Danny Dorling is Halford Mackinder Professor of Geography at the University of Oxford. Prior to joining Oxford in 2013, he worked in Sheffield, Newcastle, Bristol, Leeds, and New Zealand. Before a career in academia Danny was employed as a play-worker in children's play-schemes and in pre-school education where the underlying rationale was that playing is learning for living. He tries not to forget this. Professor Dorling’s research focuses on social inequality as it manifests in housing, health, employment, and education.
+
+- [Eventbrite (TBD)]()
+- [YouTube (after recording)]()
+- [Soundcloud (pending)]()


### PR DESCRIPTION
This adds details and pending connection information for all the speakers in the first season of the SAD interviews. 